### PR TITLE
Add a 32-bit Windows dist flavor per site request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,10 +32,17 @@ dist-build:
 		-arch="amd64" \
 		./cmd/packer > /dev/null
 
+	gox -output="dist/{{.OS}}-{{.Arch}}/data-models-packer" \
+		-ldflags "-X packer.progBuild='$(GIT_SHA)'" \
+		-os="windows" \
+		-arch="386" \
+		./cmd/packer > /dev/null
+
 dist-zip:
 	cd dist && zip data-models-packer-linux-amd64.zip linux-amd64/*
 	cd dist && zip data-models-packer-windows-amd64.zip windows-amd64/*
 	cd dist && zip data-models-packer-darwin-amd64.zip darwin-amd64/*
+	cd dist && zip data-models-packer-windows-386.zip windows-386/*
 
 dist: dist-build dist-zip
 


### PR DESCRIPTION
I stuck with the gox approach because I don't have time to muck about.  I uploaded a 32-bit Windows file for Colorado to try out.  If that works for them, we can merge this.
